### PR TITLE
set beginning evening time. Also reduced the minimize delay time

### DIFF
--- a/units/silverblue-update.timer
+++ b/units/silverblue-update.timer
@@ -27,9 +27,10 @@ Description=Daily Fedora Silverblue Update Timer
 ConditionPathExists=/run/ostree-booted
 
 [Timer]
-OnBootSec=2m
+# OnBootSec=5m
+OnCalendar=*-*-* 18:00:00
 OnUnitActiveSec=22hr
-RandomizedDelaySec=4h
+#RandomizedDelaySec=30min
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
So first I changed the default for the deactivated "start on boot".

- After 5min every system will be more at idle, even when running nextcloud (nextcloud and similar sync services hog a lot of data scanning all directories for changed files at the beginning (Database scanning)).

Then I added the "start on time of day" functionality, which should work. I dont know what the behavior is, if you have the laptop powered off, if it uses then the next possible time.

The RandomizedDelay afaik sets when the program starts if there are other programs starting at the same schedule. This should normally not happen, but as the updating should be done always after 30min I set it like that. It should never interfere with it.